### PR TITLE
feat: Implement phase plot widget and functionality

### DIFF
--- a/docked_phase_plot_widget.py
+++ b/docked_phase_plot_widget.py
@@ -1,0 +1,241 @@
+from PyQt5.QtWidgets import QTabWidget, QInputDialog, QMenu, QAction
+from PyQt5.QtCore import Qt, QSettings # QSettings might not be directly used if DockedWidget handles it
+
+from gui.docked_widget import DockedWidget # Assuming gui.docked_widget path
+from gui.phase_plot_widget import PhasePlotWidget # Assuming gui.phase_plot_widget path
+
+class DockedPhasePlotWidget(DockedWidget):
+    def __init__(self, parent, plot_manager_instance, data_file_widget_instance):
+        super().__init__("Phase Plots", parent)
+
+        self.plot_manager = plot_manager_instance
+        self.data_file_widget = data_file_widget_instance
+
+        self.tabs = QTabWidget()
+        self.setWidget(self.tabs) # Sets the main widget for the DockedWidget
+
+        self.tabs.setTabsClosable(True)
+        self.tabs.setMovable(True)
+        self.tabs.setTabBarAutoHide(False) # Or True, as per preference
+
+        # Connect signals for tab management
+        self.tabs.tabCloseRequested.connect(self.close_tab)
+        self.tabs.tabBar().customContextMenuRequested.connect(self.on_tab_bar_context_menu)
+        self.tabs.tabBar().setContextMenuPolicy(Qt.CustomContextMenu)
+        self.tabs.tabBarDoubleClicked.connect(self.rename_tab_dialog)
+        
+        # _read_settings is called by DockedWidget's constructor after this __init__
+        # So, tab loading will happen there.
+        # If _read_settings doesn't load any tabs, we add a default one.
+        # This check is now moved to the end of _read_settings itself.
+
+    def add_phase_plot_tab(self, name=None, plot_config=None):
+        # PhasePlotWidget now takes data_file_widget in its constructor.
+        new_phase_plot_widget = PhasePlotWidget(parent=self.tabs, data_file_widget=self.data_file_widget)
+
+        # Connect its time signal. PhasePlotWidget has connect_to_time_signal method.
+        # Let's use that for consistency if the signal name might vary or needs internal management.
+        # However, direct connection to update_marker is also fine and currently used.
+        # For now, keeping the direct connection as it's already in place.
+        # Option 1: Direct connection (current approach)
+        if hasattr(self.plot_manager, 'tickValueChanged'):
+            time_signal = self.plot_manager.tickValueChanged
+        elif hasattr(self.plot_manager, 'timeValueChanged'):
+            time_signal = self.plot_manager.timeValueChanged
+        else:
+            time_signal = None
+            print("Warning: PlotManager has neither tickValueChanged nor timeValueChanged signal for PhasePlotWidget.")
+
+        if time_signal:
+            # If PhasePlotWidget.connect_to_time_signal is preferred:
+            # new_phase_plot_widget.connect_to_time_signal(time_signal)
+            # For now, direct connection as it was:
+            time_signal.connect(new_phase_plot_widget.update_marker)
+
+
+        tab_name = name if name is not None else f"Phase Plot {self.tabs.count() + 1}"
+        
+        index = self.tabs.addTab(new_phase_plot_widget, tab_name)
+        self.tabs.setCurrentWidget(new_phase_plot_widget)
+
+        if plot_config is not None:
+            # PhasePlotWidget.load_plot_config now uses self.data_file_widget
+            new_phase_plot_widget.load_plot_config(plot_config)
+        
+        return new_phase_plot_widget
+
+    def close_tab(self, index):
+        widget = self.tabs.widget(index)
+        if widget:
+            # Disconnect signal to avoid issues during deletion
+            if hasattr(self.plot_manager, 'tickValueChanged'):
+                 try: widget.update_marker.disconnect() # Disconnect all signals to this slot
+                 except TypeError: pass # already disconnected or never connected
+            elif hasattr(self.plot_manager, 'timeValueChanged'):
+                 try: widget.update_marker.disconnect()
+                 except TypeError: pass
+            
+            self.tabs.removeTab(index)
+            widget.deleteLater() # Important for cleanup
+
+    def rename_tab_dialog(self, index):
+        if index < 0 or index >= self.tabs.count(): # Check if index is valid
+            # Double-clicking on empty tab bar area gives index -1 for some Qt versions
+            return 
+
+        old_name = self.tabs.tabText(index)
+        new_name, ok = QInputDialog.getText(self, "Rename Tab", "Enter new tab name:", text=old_name)
+        
+        if ok and new_name:
+            self.tabs.setTabText(index, new_name)
+
+    def on_tab_bar_context_menu(self, point):
+        menu = QMenu(self)
+        
+        add_action = menu.addAction("Add New Phase Plot")
+        add_action.triggered.connect(lambda: self.add_phase_plot_tab()) # Lambda to call without args
+
+        tab_index = self.tabs.tabBar().tabAt(point)
+        if tab_index != -1: # Check if the click was on an actual tab
+            menu.addSeparator()
+            
+            rename_action = menu.addAction("Rename Tab")
+            rename_action.triggered.connect(lambda checked=False, idx=tab_index: self.rename_tab_dialog(idx))
+
+            close_action = menu.addAction("Close Tab")
+            close_action.triggered.connect(lambda checked=False, idx=tab_index: self.close_tab(idx))
+        
+        menu.exec_(self.tabs.tabBar().mapToGlobal(point))
+
+    def _write_settings(self):
+        # DockedWidget's _write_settings already calls self.settings.beginGroup(self.windowTitle())
+        super()._write_settings() # Call parent method first
+
+        # self.settings should already be scoped by DockedWidget to self.windowTitle()
+        self.settings.beginWriteArray("tabs")
+        for i in range(self.tabs.count()):
+            self.settings.setArrayIndex(i)
+            tab_widget = self.tabs.widget(i)
+            if isinstance(tab_widget, PhasePlotWidget): # Ensure it's the correct widget type
+                self.settings.setValue("name", self.tabs.tabText(i))
+                self.settings.setValue("plot_config", tab_widget.get_plot_config())
+            else:
+                # Handle placeholder or unexpected widget type if necessary
+                self.settings.setValue("name", self.tabs.tabText(i))
+                self.settings.setValue("plot_config", []) # Save empty config for non-PhasePlotWidgets
+                print(f"Warning: Tab {i} ('{self.tabs.tabText(i)}') is not a PhasePlotWidget. Saving empty config.")
+
+        self.settings.endArray()
+        # DockedWidget's _write_settings calls self.settings.endGroup()
+
+    def _read_settings(self):
+        # DockedWidget's _read_settings already calls self.settings.beginGroup(self.windowTitle())
+        super()._read_settings() # Call parent method first
+
+        # self.settings should already be scoped
+        count = self.settings.beginReadArray("tabs")
+        for i in range(count):
+            self.settings.setArrayIndex(i)
+            name = self.settings.value("name")
+            plot_config = self.settings.value("plot_config")
+            # Ensure plot_config is a list, QSettings might return single item if array had one element
+            if not isinstance(plot_config, list) and plot_config is not None: 
+                plot_config = [plot_config] 
+            elif plot_config is None: # Handle case where plot_config might be None
+                plot_config = []
+                
+            self.add_phase_plot_tab(name=name, plot_config=plot_config)
+        self.settings.endArray()
+        
+        if self.tabs.count() == 0: # If no tabs were loaded (e.g., first run)
+            self.add_phase_plot_tab(name="Default Phase Plot")
+        # DockedWidget's _read_settings calls self.settings.endGroup()
+
+    # closeEvent is handled by DockedWidget, which calls _write_settings.
+    # Child QWidgets (QTabWidget, PhasePlotWidgets) are managed by Qt's
+    # parent-child hierarchy for deletion when DockedPhasePlotWidget is closed.
+    # The explicit deleteLater in close_tab handles individual tab closures.
+
+# Example usage (requires DockedWidget, PhasePlotWidget, and mock plot_manager, data_file_widget):
+if __name__ == '__main__':
+    from PyQt5.QtWidgets import QApplication, QMainWindow
+    import sys
+
+    # --- Mockups for testing ---
+    class MockPlotManager:
+        def __init__(self):
+            # Mock a signal like tickValueChanged or timeValueChanged
+            self.tickValueChanged = pg.SignalProxy(None, slot=self.emit_tick, PUSH_MODE="Weakref") # Example, requires pyqtgraph for SignalProxy
+            self._callbacks = []
+
+        def connect_tick_value_changed(self, func): # Actual connection mechanism might vary
+            # self.tickValueChanged.connect(func)
+            self._callbacks.append(func)
+            return func
+        
+        def disconnect_tick_value_changed(self, func_ref):
+            # self.tickValueChanged.disconnect(func_ref)
+            if func_ref in self._callbacks:
+                self._callbacks.remove(func_ref)
+
+        def emit_tick(self, tick_value): # Simulate emitting the signal
+            # self.tickValueChanged.emit(tick_value) # If using actual pg.SignalProxy
+            for cb in self._callbacks:
+                cb(tick_value)
+
+    class MockDataFileWidget:
+        def __init__(self):
+            self.sources = {} # Assuming it stores by filename now for consistency with PhasePlotWidget needs
+        
+        def add_source(self, source): # Assuming source has a 'filename' attribute
+            if hasattr(source, 'filename'):
+                self.sources[source.filename] = source
+            else: # Fallback for older mock source structure if any
+                self.sources[source.name()] = source
+
+        # This method is used by PhasePlotWidget.load_plot_config
+        def get_data_file_by_name(self, source_id): 
+            return self.sources.get(source_id)
+        
+        # Keep get_source_by_id if it's used by other parts of the test setup,
+        # but ensure get_data_file_by_name is what PhasePlotWidget expects.
+        def get_source_by_id(self, source_id): # Potentially an alias or different lookup
+            return self.sources.get(source_id)
+
+
+    # Need pyqtgraph for SignalProxy if used in MockPlotManager
+    import pyqtgraph as pg 
+
+    # --- Main Application Setup ---
+    app = QApplication(sys.argv)
+    # Required for QSettings to work without specifying org/app name
+    app.setOrganizationName("TestOrg")
+    app.setApplicationName("TestApp")
+    
+    main_window = QMainWindow()
+    main_window.setCentralWidget(QLabel("Main Window Area")) # Placeholder
+
+    # Instantiate mock dependencies
+    mock_plot_mgr = MockPlotManager()
+    mock_df_widget = MockDataFileWidget()
+
+    # Create and add the docked widget
+    docked_phase_plot = DockedPhasePlotWidget(main_window, mock_plot_mgr, mock_df_widget)
+    main_window.addDockWidget(Qt.RightDockWidgetArea, docked_phase_plot)
+    
+    # Example: Add some mock data sources to data_file_widget for testing config load
+    import numpy as np
+    class MockDataSource:
+        def __init__(self, filename, data_map): # Changed 'name' to 'filename' for clarity
+            self.filename = filename # Ensure filename attribute exists
+            self._name = filename # Keep _name if other parts of mock rely on it
+            self.data = data_map
+        def model(self): return self
+        def get_data_by_name(self, var_name): return self.data.get(var_name)
+        def name(self): return self._name # For compatibility if .name() is still used by some mock parts
+
+    source1 = MockDataSource("Engine.csv", {"rpm": np.array([1,2,3]), "torque": np.array([10,20,30])})
+    mock_df_widget.add_source(source1)
+
+    main_window.show()
+    sys.exit(app.exec_())

--- a/docked_phase_plot_widget.py
+++ b/docked_phase_plot_widget.py
@@ -31,8 +31,8 @@ class DockedPhasePlotWidget(DockedWidget):
         # This check is now moved to the end of _read_settings itself.
 
     def add_phase_plot_tab(self, name=None, plot_config=None):
-        # PhasePlotWidget now takes data_file_widget in its constructor.
-        new_phase_plot_widget = PhasePlotWidget(parent=self.tabs, data_file_widget=self.data_file_widget)
+        # PhasePlotWidget now takes data_file_widget and plot_manager in its constructor.
+        new_phase_plot_widget = PhasePlotWidget(parent=self.tabs, data_file_widget=self.data_file_widget, plot_manager=self.plot_manager)
 
         # Connect its time signal. PhasePlotWidget has connect_to_time_signal method.
         # Let's use that for consistency if the signal name might vary or needs internal management.
@@ -48,9 +48,7 @@ class DockedPhasePlotWidget(DockedWidget):
             print("Warning: PlotManager has neither tickValueChanged nor timeValueChanged signal for PhasePlotWidget.")
 
         if time_signal:
-            # If PhasePlotWidget.connect_to_time_signal is preferred:
-            # new_phase_plot_widget.connect_to_time_signal(time_signal)
-            # For now, direct connection as it was:
+            # Connect marker updates (individual traces connect themselves to value updates)
             time_signal.connect(new_phase_plot_widget.update_marker)
 
 

--- a/docked_phase_plot_widget.py
+++ b/docked_phase_plot_widget.py
@@ -150,6 +150,13 @@ class DockedPhasePlotWidget(DockedWidget):
             self.add_phase_plot_tab(name="Default Phase Plot")
         # DockedWidget's _read_settings calls self.settings.endGroup()
 
+    def update_all_marker_settings(self):
+        """Update marker settings for all phase plot widgets in all tabs"""
+        for i in range(self.tabs.count()):
+            phase_plot_widget = self.tabs.widget(i)
+            if hasattr(phase_plot_widget, 'update_marker_settings_from_preferences'):
+                phase_plot_widget.update_marker_settings_from_preferences()
+
     # closeEvent is handled by DockedWidget, which calls _write_settings.
     # Child QWidgets (QTabWidget, PhasePlotWidgets) are managed by Qt's
     # parent-child hierarchy for deletion when DockedPhasePlotWidget is closed.

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from PyQt5.QtWidgets import (QAction, QApplication, QFileDialog, QLabel,
 from data_file_widget import DataFileWidget
 from plot_manager import PlotManager
 from visualizer_3d_widget import DockedVisualizer3DWidget
+from docked_phase_plot_widget import DockedPhasePlotWidget # Added for Phase Plot
 
 _visualizer_available = True
 # try:
@@ -69,6 +70,8 @@ class PyPlot(QMainWindow):
         self.show_text_logs_action = None
         self.maths_widget_action = None
         self.visualizer_3d_action = None
+        self.show_phase_plot_action = None # Added for Phase Plot
+        self.phase_plot_widget = None # Added for Phase Plot
 
         q_splitter = QSplitter(self)
         q_splitter.setObjectName("qSplitter")
@@ -203,6 +206,39 @@ class PyPlot(QMainWindow):
         self.show_text_logs_action.triggered.connect(self.create_or_destroy_text_log_widget)
         tool_menu.addAction(self.show_text_logs_action)
 
+        tool_menu.addSeparator() # Optional: separate generic tools from plot-specific tools
+
+        self.show_phase_plot_action = QAction("Show Phase Plots", self)
+        self.show_phase_plot_action.setStatusTip("Show the phase plot widget")
+        self.show_phase_plot_action.setCheckable(True)
+        self.show_phase_plot_action.triggered.connect(self.create_or_destroy_phase_plot_widget)
+        tool_menu.addAction(self.show_phase_plot_action)
+
+    def create_or_destroy_phase_plot_widget(self, is_checked):
+        if is_checked:
+            if not self.phase_plot_widget:
+                # Pass the plot_manager and data_file_widget instances
+                self.phase_plot_widget = DockedPhasePlotWidget(
+                    parent=self,
+                    plot_manager_instance=self.plot_manager,
+                    data_file_widget_instance=self.data_file_widget
+                )
+                self.addDockWidget(Qt.RightDockWidgetArea, self.phase_plot_widget) # Or another default area
+
+                # Define a slot to handle the onClose signal from DockedPhasePlotWidget
+                @pyqtSlot()
+                def on_phase_plot_closed():
+                    self.show_phase_plot_action.setChecked(False)
+                    # self.phase_plot_widget.deleteLater() # DockedWidget base class should handle this if closed by 'x'
+                    self.phase_plot_widget = None
+
+                self.phase_plot_widget.onClose.connect(on_phase_plot_closed)
+            else:
+                self.phase_plot_widget.show()
+        else:
+            if self.phase_plot_widget: # Check if it exists
+                self.phase_plot_widget.hide()
+
     def create_visualizer_window(self, is_checked):
         if is_checked:
             if not self.visualizer_3d:
@@ -293,6 +329,8 @@ class PyPlot(QMainWindow):
                                                  self.maths_widget.isHidden())))
         settings.setValue("show_text_log", int(not (self.text_log_widget is None or
                                                     self.text_log_widget.isHidden())))
+        settings.setValue("show_phase_plot", int(not (self.phase_plot_widget is None or
+                                                      self.phase_plot_widget.isHidden())))
         settings.endGroup()
 
         settings.sync()
@@ -320,6 +358,14 @@ class PyPlot(QMainWindow):
         if show_text_log:
             self.show_text_logs_action.setChecked(True)
             self.create_or_destroy_text_log_widget(True)
+        
+        show_phase_plot = bool(int(self._settings.value("show_phase_plot", 0)))
+        if show_phase_plot:
+            if self.show_phase_plot_action: # Ensure action exists
+                self.show_phase_plot_action.setChecked(True)
+            # This will create the widget, and its own _read_settings will be called by DockedWidget constructor
+            self.create_or_destroy_phase_plot_widget(True)
+
 
         self._settings.endGroup()
 
@@ -332,6 +378,8 @@ class PyPlot(QMainWindow):
             self.maths_widget.close()
         if self.text_log_widget:
             self.text_log_widget.close()
+        if self.phase_plot_widget:
+            self.phase_plot_widget.close() # This will trigger its _write_settings
 
         event.accept()
 

--- a/main.py
+++ b/main.py
@@ -358,7 +358,7 @@ class PyPlot(QMainWindow):
         if show_text_log:
             self.show_text_logs_action.setChecked(True)
             self.create_or_destroy_text_log_widget(True)
-        
+
         show_phase_plot = bool(int(self._settings.value("show_phase_plot", 0)))
         if show_phase_plot:
             if self.show_phase_plot_action: # Ensure action exists
@@ -431,6 +431,11 @@ class PyPlot(QMainWindow):
         prefs = PreferencesDialog(parent=self)
         if prefs.exec():
             prefs.saveSettings()
+            # Update all existing plot widgets with new settings
+            self.plot_manager.update_all_cursor_settings()
+            # Update phase plot markers if phase plot widget exists
+            if self.phase_plot_widget and hasattr(self.phase_plot_widget, 'update_all_marker_settings'):
+                self.phase_plot_widget.update_all_marker_settings()
 
     def save_plotlist(self):
         dir = self._get_last_dir("last_plotlist_dir")

--- a/phase_plot_item.py
+++ b/phase_plot_item.py
@@ -1,0 +1,110 @@
+import pyqtgraph as pg
+import numpy as np
+
+PEN_WIDTH = 2
+
+class PhasePlotItem:
+    def __init__(self, source_x, var_name_x, source_y, var_name_y, pen, name=None):
+        self.source_x = source_x
+        self.var_name_x = var_name_x
+        self.source_y = source_y
+        self.var_name_y = var_name_y
+        self.pen = pen if pen is not None else pg.mkPen(color='w', width=PEN_WIDTH)
+        self._name = name if name is not None else f"{var_name_x} vs {var_name_y}"
+
+        # Assume source has model() and get_data_by_name()
+        # and that get_data_by_name returns a numpy array
+        self.data_x = self.source_x.model().get_data_by_name(self.var_name_x)
+        self.data_y = self.source_y.model().get_data_by_name(self.var_name_y)
+
+        if self.data_x is None:
+            self.data_x = np.array([])
+            print(f"Warning: Data for {self.var_name_x} not found.")
+        if self.data_y is None:
+            self.data_y = np.array([])
+            print(f"Warning: Data for {self.var_name_y} not found.")
+
+        self.plot_data_item = pg.PlotDataItem(self.data_x, self.data_y, pen=self.pen, name=self._name)
+
+    def update_data(self, source_x, var_name_x, source_y, var_name_y):
+        self.source_x = source_x
+        self.var_name_x = var_name_x
+        self.source_y = source_y
+        self.var_name_y = var_name_y
+
+        new_data_x = self.source_x.model().get_data_by_name(self.var_name_x)
+        new_data_y = self.source_y.model().get_data_by_name(self.var_name_y)
+
+        self.data_x = new_data_x if new_data_x is not None else np.array([])
+        self.data_y = new_data_y if new_data_y is not None else np.array([])
+        
+        if new_data_x is None:
+            print(f"Warning: Data for {self.var_name_x} not found during update.")
+        if new_data_y is None:
+            print(f"Warning: Data for {self.var_name_y} not found during update.")
+
+        self.plot_data_item.setData(self.data_x, self.data_y)
+        # Update name if it was default and var names changed
+        if self._name == f"{self.var_name_x} vs {self.var_name_y}" or self._name == f"{var_name_x} vs {var_name_y}": # old default name
+             self._name = f"{self.var_name_x} vs {self.var_name_y}"
+             # self.plot_data_item.opts['name'] = self._name # Not directly settable, might need to recreate or manage legend separately
+
+    def setPen(self, pen):
+        self.pen = pen
+        self.plot_data_item.setPen(self.pen)
+
+    def name(self):
+        return self._name
+
+    def get_data_at_tick(self, tick_index):
+        # Check if data_x and data_y are valid and have data
+        if self.data_x is None or self.data_y is None:
+            return None
+        
+        len_x = len(self.data_x)
+        len_y = len(self.data_y)
+
+        if tick_index < 0: # Allow negative indexing? For now, no.
+            return None
+
+        # Handle cases where one or both datasets might be too short or empty
+        if tick_index >= len_x or tick_index >= len_y:
+            # If one is long enough, should we return partial data or None?
+            # For an X-Y plot, both are needed.
+            return None
+        
+        # Handle empty arrays specifically, though len check above should cover it.
+        if len_x == 0 or len_y == 0:
+            return None
+
+        return self.data_x[tick_index], self.data_y[tick_index]
+
+    def get_plot_spec(self):
+        # Assuming self.source_x and self.source_y are objects (e.g., DataFile instances)
+        # that have a .filename attribute.
+        source_x_filename = None
+        if hasattr(self.source_x, 'filename'):
+            source_x_filename = self.source_x.filename
+        else:
+            print(f"Warning: source_x for '{self.var_name_x}' does not have a 'filename' attribute. Plot spec may be incomplete.")
+
+        source_y_filename = None
+        if hasattr(self.source_y, 'filename'):
+            source_y_filename = self.source_y.filename
+        else:
+            print(f"Warning: source_y for '{self.var_name_y}' does not have a 'filename' attribute. Plot spec may be incomplete.")
+
+        return {
+            'source_x_id': source_x_filename, # Changed from x_source_name
+            'x_var': self.var_name_x,
+            'source_y_id': source_y_filename, # Changed from y_source_name
+            'y_var': self.var_name_y,
+            'color': self.pen.color().name(),  # e.g., '#FF0000'
+            'width': self.pen.width(),
+            'name': self._name
+        }
+
+    # It might be useful to have a method to get the actual PlotDataItem
+    # for adding to a plot widget.
+    def get_qt_item(self):
+        return self.plot_data_item

--- a/phase_plot_widget.py
+++ b/phase_plot_widget.py
@@ -1,0 +1,605 @@
+import pyqtgraph as pg
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QMenu, QAction, QMessageBox
+from PyQt5.QtGui import QPalette, QColor, QKeyEvent # Added QKeyEvent for keyPressEvent
+from PyQt5.QtCore import Qt, QVariant, QSettings # Added QSettings
+import pickle
+
+# Assuming flow_layout.py is in the same directory or Python path
+# from flow_layout import FlowLayout 
+# For now, I'll mock FlowLayout if it's not available in the environment.
+# If it's a custom class, it needs to be provided.
+try:
+    from flow_layout import FlowLayout
+except ImportError:
+    print("Warning: FlowLayout not found. Using QVBoxLayout as a placeholder for legend_layout.")
+    class FlowLayout(QVBoxLayout): # Placeholder
+        def __init__(self, parent=None):
+            super().__init__(parent)
+            self.widgets = []
+
+        def addWidget(self, widget):
+            super().addWidget(widget)
+            self.widgets.append(widget)
+
+        def takeAt(self, index):
+            if 0 <= index < len(self.widgets):
+                widget = self.widgets.pop(index)
+                return self.itemAt(index) # QVBoxLayout specific
+            return None
+        
+        def count(self):
+            return len(self.widgets)
+        
+        def clear(self): # Custom clear for placeholder
+            while self.count():
+                child = self.takeAt(0)
+                if child:
+                    widget = child.widget()
+                    if widget:
+                        widget.deleteLater()
+            self.widgets = []
+
+
+from phase_plot_item import PhasePlotItem, PEN_WIDTH # PEN_WIDTH is from phase_plot_item
+import numpy as np
+
+class PhasePlotWidget(QWidget):
+    # Copied from a typical SubPlotWidget.COLORS, adjust if different
+    COLORS = (
+        (255, 0, 0), (0, 255, 0), (0, 0, 255), (255, 255, 0), (0, 255, 255),
+        (255, 0, 255), (200, 100, 0), (100, 200, 0), (0, 200, 100), (0, 100, 200),
+        (100, 0, 200), (200, 0, 100)
+    )
+    # Using PEN_WIDTH from PhasePlotItem
+
+    def __init__(self, parent, data_file_widget): # Modified signature
+        super().__init__(parent)
+        self.data_file_widget = data_file_widget # Store data_file_widget
+        self.main_layout = QVBoxLayout(self)
+
+        self.legend_layout = FlowLayout() # Or QVBoxLayout if FlowLayout is not found
+        self.main_layout.addLayout(self.legend_layout)
+
+        # Status label for drag-and-drop
+        self.status_label = QLabel("Drop X variable, then Y variable to create a trace.")
+        self.main_layout.addWidget(self.status_label)
+
+        self.plot_widget = pg.PlotWidget()
+        self.plot_widget.setBackground('w')
+        self.plot_widget.showGrid(x=True, y=True)
+        self.plot_widget.getPlotItem().hideButtons()
+        self.plot_widget.getPlotItem().setMenuEnabled(enableMenu=False, enableViewBoxMenu=False)
+        self.main_layout.addWidget(self.plot_widget)
+
+        self._traces = []
+        
+        # Marker related attributes
+        self.cursor_marker_item = None # For scatter plot markers ('o', 's', etc.)
+        self.cursor_crosshair_h = None # For horizontal line of crosshair
+        self.cursor_crosshair_v = None # For vertical line of crosshair
+        self.last_tick_index = 0       # To store the last known tick index
+
+        # Load default marker settings
+        settings = QSettings()
+        self.current_marker_type = settings.value("phase_plot/default_marker_type", "Circle")
+        self.current_marker_size = int(settings.value("phase_plot/default_marker_size", 10))
+        # Default color: Red, semi-transparent. Consider making this configurable later.
+        self.current_marker_color_tuple = (255, 0, 0, 120) 
+
+        self.time_signal_connection = None # To store the connection
+        self.color_index = 0
+
+        self.pending_x_var_name = None
+        self.pending_x_source_id = None # Will store filename of the source for X
+
+        self.setAcceptDrops(True) # Enable drop events for the widget
+        self.setFocusPolicy(Qt.StrongFocus) # For keyboard events
+        
+        self.setLayout(self.main_layout)
+
+    def keyPressEvent(self, event: QKeyEvent):
+        if event.key() == Qt.Key_A and event.modifiers() & Qt.ControlModifier:
+            self.autoscale_plot()
+            event.accept()
+        else:
+            # Important to call super to allow other key events 
+            # to be processed if this widget doesn't handle them.
+            super().keyPressEvent(event)
+
+    def dragEnterEvent(self, event):
+        if event.mimeData().hasFormat("application/x-DataItem"):
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dropEvent(self, event):
+        if event.mimeData().hasFormat("application/x-DataItem"):
+            byte_array = event.mimeData().retrieveData("application/x-DataItem", QVariant.ByteArray)
+            try:
+                # data_item is an instance of DataItem from data_model.py
+                data_item = pickle.loads(byte_array)
+            except Exception as e:
+                print(f"Error unpickling DataItem: {e}")
+                self.status_label.setText("Error processing dropped item.")
+                event.ignore()
+                return
+
+            # Assuming data_item has 'name' (variable name) and 'source' (DataFile object with 'filename')
+            if not hasattr(data_item, 'name') or not hasattr(data_item, 'source') or not hasattr(data_item.source, 'filename'):
+                print("Error: Dropped DataItem is not structured as expected (missing name, source, or source.filename).")
+                self.status_label.setText("Error: Invalid data item dropped.")
+                QMessageBox.warning(self, "Drop Error", "The dropped item does not contain the necessary information (variable name or source file).")
+                event.ignore()
+                return
+
+            current_var_name = data_item.name
+            current_source_id = data_item.source.filename # filename of the source DataFile
+
+            if self.pending_x_var_name is None:
+                # This is the first drop (X variable)
+                self.pending_x_var_name = current_var_name
+                self.pending_x_source_id = current_source_id
+                self.status_label.setText(f"X: {self.pending_x_var_name} (from {self.pending_x_source_id}). Drop Y variable.")
+                event.acceptProposedAction()
+            else:
+                # This is the second drop (Y variable)
+                source_x = self.data_file_widget.get_data_file_by_name(self.pending_x_source_id)
+                source_y = self.data_file_widget.get_data_file_by_name(current_source_id)
+
+                if source_x and source_y:
+                    self.add_trace(source_x, self.pending_x_var_name, source_y, current_var_name)
+                    self.status_label.setText("Trace added. Drop X variable, then Y variable for a new trace.")
+                else:
+                    error_msg = "Error: Could not find data source(s).\n"
+                    if not source_x:
+                        error_msg += f" - Source for X ('{self.pending_x_source_id}') not found.\n"
+                    if not source_y:
+                        error_msg += f" - Source for Y ('{current_source_id}') not found.\n"
+                    error_msg += "Cleared pending X variable."
+                    
+                    self.status_label.setText(error_msg)
+                    QMessageBox.warning(self, "Error Adding Trace", error_msg)
+                
+                # Reset pending X for the next trace
+                self.clear_pending_x_variable() 
+                event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def clear_pending_x_variable(self):
+        self.pending_x_var_name = None
+        self.pending_x_source_id = None
+        self.status_label.setText("Drop X variable, then Y variable to create a trace.")
+
+
+    def add_trace(self, source_x, var_name_x, source_y, var_name_y, color_str=None, name=None):
+        if color_str:
+            color = pg.mkColor(color_str)
+        else:
+            r, g, b = self.COLORS[self.color_index % len(self.COLORS)]
+            color = pg.mkColor(r, g, b)
+            self.color_index += 1
+        
+        pen = pg.mkPen(color=color, width=PEN_WIDTH)
+        
+        # Use provided name or generate default for PhasePlotItem
+        trace_name = name if name else f"{var_name_x}_vs_{var_name_y}"
+        item = PhasePlotItem(source_x, var_name_x, source_y, var_name_y, pen, name=trace_name)
+        
+        self.plot_widget.getPlotItem().addItem(item.get_qt_item())
+        self._traces.append(item)
+        self._update_legend()
+        return item # Return the item in case the caller wants to interact with it
+
+    def remove_trace(self, phase_plot_item_instance):
+        if phase_plot_item_instance in self._traces:
+            self.plot_widget.getPlotItem().removeItem(phase_plot_item_instance.get_qt_item())
+            self._traces.remove(phase_plot_item_instance)
+            self._update_legend()
+            self.update_marker(self.last_tick_index) # Update markers as a trace was removed
+
+    def clear_plot(self):
+        for item in self._traces:
+            self.plot_widget.getPlotItem().removeItem(item.get_qt_item())
+        self._traces = []
+        self.color_index = 0 # Reset color index
+        self._update_legend()
+        
+        # Explicitly clear/hide all marker types
+        if self.cursor_marker_item:
+            self.cursor_marker_item.setData(spots=[])
+        if self.cursor_crosshair_h:
+            self.cursor_crosshair_h.hide()
+        if self.cursor_crosshair_v:
+            self.cursor_crosshair_v.hide()
+        # Ensure last_tick_index is reset or handled appropriately if needed,
+        # but for now, just clearing markers is fine.
+
+
+    def _update_legend(self):
+        # Clear existing legend items
+        # Proper way to clear FlowLayout items:
+        while self.legend_layout.count():
+            item = self.legend_layout.takeAt(0)
+            widget = item.widget()
+            if widget:
+                widget.deleteLater()
+
+        for trace_item in self._traces:
+            # Use var_name_x and var_name_y from PhasePlotItem for legend text
+            legend_text = f"x: {trace_item.var_name_x} - y: {trace_item.var_name_y}"
+            label = QLabel(legend_text)
+            
+            # Set text color to match trace color
+            qcolor = trace_item.pen.color() # This is a QColor
+            label.setStyleSheet(f"color: {qcolor.name()}")
+            
+            self.legend_layout.addWidget(label)
+
+    def update_marker(self, tick_index):
+        self.last_tick_index = tick_index
+
+        valid_points = []
+        if self._traces: # Only proceed if there are traces
+            for trace in self._traces:
+                point_data = trace.get_data_at_tick(tick_index)
+                if point_data is not None:
+                    valid_points.append(point_data) # Store as (x,y) tuples
+
+        # Hide all markers initially
+        if self.cursor_marker_item:
+            self.cursor_marker_item.setData(spots=[]) # Clear data to hide
+        if self.cursor_crosshair_h:
+            self.cursor_crosshair_h.hide()
+        if self.cursor_crosshair_v:
+            self.cursor_crosshair_v.hide()
+
+        if not valid_points: # No valid points at this tick_index for any trace
+            return
+
+        # Marker Type Handling
+        if self.current_marker_type == "Crosshairs":
+            if self.cursor_crosshair_h is None or self.cursor_crosshair_v is None:
+                # Use only RGB for pen color, alpha is not typically used for InfiniteLine pen
+                crosshair_pen = pg.mkPen(color=self.current_marker_color_tuple[:3], width=1)
+                self.cursor_crosshair_h = pg.InfiniteLine(angle=0, movable=False, pen=crosshair_pen)
+                self.cursor_crosshair_v = pg.InfiniteLine(angle=90, movable=False, pen=crosshair_pen)
+                self.plot_widget.addItem(self.cursor_crosshair_h, ignoreBounds=True)
+                self.plot_widget.addItem(self.cursor_crosshair_v, ignoreBounds=True)
+            
+            # Use the first point in valid_points for crosshair position
+            primary_point = valid_points[0] # This is an (x,y) tuple
+            self.cursor_crosshair_h.setPos(primary_point[1]) # Horizontal line at Y value
+            self.cursor_crosshair_v.setPos(primary_point[0]) # Vertical line at X value
+            self.cursor_crosshair_h.show()
+            self.cursor_crosshair_v.show()
+        else: # Scatter plot markers ("Circle", "Square", etc.)
+            symbol_map = {"Circle": "o", "Square": "s"} # Add more if needed (e.g. "Star": "*", "Plus": "+", "Triangle": "t")
+            actual_symbol = symbol_map.get(self.current_marker_type, "o") # Default to circle
+
+            if self.cursor_marker_item is None:
+                self.cursor_marker_item = pg.ScatterPlotItem(pen=pg.mkPen(None)) # No border pen for markers
+                self.plot_widget.addItem(self.cursor_marker_item)
+            
+            self.cursor_marker_item.setSize(self.current_marker_size)
+            self.cursor_marker_item.setBrush(pg.mkBrush(*self.current_marker_color_tuple))
+            
+            # Prepare spots data with the correct symbol for all points
+            spots_data = [{'pos': p, 'symbol': actual_symbol, 'data': 1} for p in valid_points]
+            self.cursor_marker_item.setData(spots=spots_data)
+            # ScatterPlotItem is automatically shown when data is set.
+
+    def set_marker_style(self, marker_type=None, size=None, color_tuple=None):
+        """
+        Sets the style for the cursor marker.
+        If a parameter is None, the existing or default setting for that aspect is used.
+        """
+        settings = QSettings()
+        if marker_type is not None:
+            self.current_marker_type = marker_type
+        else: # Re-read from settings if not provided (e.g. if called from preferences update)
+            self.current_marker_type = settings.value("phase_plot/default_marker_type", "Circle")
+
+        if size is not None:
+            self.current_marker_size = int(size)
+        else:
+            self.current_marker_size = int(settings.value("phase_plot/default_marker_size", 10))
+
+        if color_tuple is not None:
+            self.current_marker_color_tuple = color_tuple
+        # else: keep the current_marker_color_tuple (e.g. (255,0,0,120) or allow future setting)
+
+        # Apply changes immediately by refreshing the marker display
+        self.update_marker(self.last_tick_index)
+    
+    def autoscale_plot(self):
+        self.plot_widget.getPlotItem().autoRange()
+
+    def _create_context_menu(self):
+        menu = QMenu(self)
+        autoscale_action = menu.addAction("Autoscale Plot")
+        autoscale_action.triggered.connect(self.autoscale_plot)
+        
+        clear_action = menu.addAction("Clear Plot")
+        clear_action.triggered.connect(self.clear_plot)
+
+        menu.addSeparator()
+
+        clear_pending_x_action = menu.addAction("Clear Pending X Variable")
+        clear_pending_x_action.triggered.connect(self.clear_pending_x_variable)
+        clear_pending_x_action.setEnabled(self.pending_x_var_name is not None)
+        
+        # TODO: Add action to add new trace? (might be complex here)
+        # TODO: Add action to remove specific trace? (needs sub-menu or dialog)
+        return menu
+
+    def contextMenuEvent(self, event):
+        menu = self._create_context_menu()
+        menu.exec_(event.globalPos())
+
+    def connect_to_time_signal(self, time_emitter_signal):
+        # Disconnect previous connection if any
+        if self.time_signal_connection:
+            try:
+                time_emitter_signal.disconnect(self.time_signal_connection)
+            except TypeError: # Catches "native Qt signal is not connected"
+                pass 
+        
+        self.time_signal_connection = time_emitter_signal.connect(self.update_marker)
+
+    def get_plot_config(self):
+        return [item.get_plot_spec() for item in self._traces]
+
+    def load_plot_config(self, config_list): # Removed data_file_widget from args, use self.data_file_widget
+        self.clear_plot()
+        for spec in config_list:
+            source_x_id = spec.get('source_x_id') # Updated key from PhasePlotItem
+            source_y_id = spec.get('source_y_id') # Updated key from PhasePlotItem
+            var_x = spec.get('x_var')
+            var_y = spec.get('y_var')
+            color = spec.get('color')
+            name = spec.get('name') # Get trace name from spec
+
+            if not all([source_x_id, var_x, source_y_id, var_y]): # Check all essential parts
+                print(f"Warning: Incomplete plot specification: {spec}. Skipping.")
+                continue
+            
+            if self.data_file_widget is None:
+                print("Error: data_file_widget is not available in PhasePlotWidget. Cannot load plot config.")
+                QMessageBox.critical(self, "Load Error", "Data file handler not available. Cannot load traces.")
+                return
+
+            try:
+                # Use self.data_file_widget.get_data_file_by_name (as it exists in DataFileWidget)
+                source_x = self.data_file_widget.get_data_file_by_name(source_x_id)
+                source_y = self.data_file_widget.get_data_file_by_name(source_y_id)
+            except AttributeError:
+                 print(f"Error: self.data_file_widget is missing 'get_data_file_by_name' method.")
+                 QMessageBox.critical(self, "Load Error", "Data file handler is missing an expected method.")
+                 return # Stop further processing
+            except Exception as e: # Catch other errors from get_data_file_by_name
+                 print(f"Error retrieving source: {e} for spec {spec}")
+                 QMessageBox.warning(self, "Load Error", f"Error retrieving source for trace '{name or f'{var_x}/{var_y}'}': {e}")
+                 continue
+
+
+            if source_x and source_y:
+                self.add_trace(source_x, var_x, source_y, var_y, color_str=color, name=name)
+            else:
+                warning_msg = f"Warning: Could not find sources for plot specification: {spec}.\n"
+                if not source_x:
+                    warning_msg += f" - Source X ('{source_x_id}') not found.\n"
+                if not source_y:
+                    warning_msg += f" - Source Y ('{source_y_id}') not found.\n"
+                print(warning_msg)
+                QMessageBox.warning(self, "Load Warning", warning_msg)
+
+    def get_traces(self):
+        """Returns the list of PhasePlotItem instances."""
+        return self._traces
+
+    def get_plot_widget(self):
+        """Returns the internal pyqtgraph.PlotWidget instance."""
+        return self.plot_widget
+
+# Example Usage (for testing purposes, if run directly)
+if __name__ == '__main__':
+    from PyQt5.QtWidgets import QApplication
+    import sys
+    import time
+
+    # Mock Data Source for testing
+    class MockDataSource:
+        def __init__(self, name, data_map):
+            self._name = name
+            self.data = data_map # e.g., {'rpm': np.array([...]), 'torque': np.array([...])}
+        
+        def model(self): # To mimic the structure PhasePlotItem expects
+            return self
+        
+        def get_data_by_name(self, var_name):
+            return self.data.get(var_name)
+
+        def name(self): # For get_plot_spec and load_plot_config
+            return self._name
+
+    # Mock DataFileWidget for testing load_plot_config
+    class MockDataFileWidget:
+        def __init__(self):
+            self.sources = {} # filename: MockDataSource
+
+        def add_source(self, source):
+            # In actual DataFileWidget, sources are likely stored by filename
+            self.sources[source.filename] = source # Assuming source has .filename
+        
+        def get_data_file_by_name(self, source_id): # Matching method name in DataFileWidget
+            return self.sources.get(source_id)
+        
+        # Mock DataItem for drag-drop testing
+        class MockDataItem:
+            def __init__(self, name, source_obj):
+                self.name = name # var_name
+                self.source = source_obj # MockDataSource which has .filename
+
+    # Mock time emitter signal
+    class TimeEmitter:
+        def __init__(self):
+            self.tickValueChanged = pg.SignalProxy(None, slot=self.emit_tick, PUSH_MODE="Weakref") # Mocking a signal
+            self._callbacks = []
+
+        def connect(self, callback):
+            self._callbacks.append(callback)
+            return callback # Return something to "disconnect"
+
+        def disconnect(self, callback_ref):
+            if callback_ref in self._callbacks:
+                self._callbacks.remove(callback_ref)
+        
+        def emit_tick(self, tick):
+            for cb in self._callbacks:
+                cb(tick)
+
+    app = QApplication(sys.argv)
+    
+    # Create mock data
+    t = np.linspace(0, 10, 500)
+    source1_data_x = np.sin(t)
+    source1_data_y = np.cos(t)
+    source2_data_x = 0.5 * np.sin(t + np.pi/2)
+    source2_data_y = 0.5 * np.cos(t - np.pi/2)
+
+    # For MockDataSource, add filename attribute
+    MockDataSource.__init__ = lambda self, filename, data_map: (setattr(self, 'filename', filename), setattr(self, 'data', data_map))
+    mock_source1 = MockDataSource("EngineData.csv", {'rpm': source1_data_x, 'load': source1_data_y})
+    mock_source2 = MockDataSource("TransmissionData.log", {'speed': source2_data_x, 'torque': source2_data_y})
+    
+    mock_dfw_for_init = MockDataFileWidget() # For PhasePlotWidget constructor
+    mock_dfw_for_init.add_source(mock_source1)
+    mock_dfw_for_init.add_source(mock_source2)
+
+
+    # Setup widget
+    main_window = PhasePlotWidget(parent=None, data_file_widget=mock_dfw_for_init)
+    
+    # Add traces
+    trace1 = main_window.add_trace(mock_source1, 'rpm', mock_source1, 'load', name="Engine RPM vs Load")
+    trace2 = main_window.add_trace(mock_source2, 'speed', mock_source2, 'torque', name="Trans Speed vs Torque")
+
+    # Test remove trace
+    # main_window.remove_trace(trace1)
+
+    # Test clear plot
+    # main_window.clear_plot()
+    # main_window.add_trace(mock_source1, 'rpm', mock_source1, 'load') # Re-add one
+
+    main_window.show()
+    main_window.autoscale_plot()
+
+    # Test marker
+    mock_time_emitter = TimeEmitter()
+    main_window.connect_to_time_signal(mock_time_emitter)
+
+    # Test get_plot_config
+    config = main_window.get_plot_config()
+    print("Plot Config:", config)
+
+    # Test load_plot_config (uses self.data_file_widget passed in constructor)
+    # To test load, clear current traces and load them back from config
+    # print("Plot Config before save:", config)
+    # main_window.clear_plot() 
+    # print("Loading config...")
+    # main_window.load_plot_config(config) # No longer needs mock_dfw as arg
+    # print("Config loaded.")
+    # main_window.autoscale_plot()
+
+
+    # --- Test Drag and Drop ---
+    # Simulate a drop event
+    def simulate_drop(var_name, source_obj):
+        data_item_instance = MockDataItem(var_name, source_obj)
+        pickled_data = pickle.dumps(data_item_instance)
+        
+        # Create a mock MimeData
+        class MockMimeData:
+            def __init__(self):
+                self._data = {}
+            def hasFormat(self, mime_type):
+                return mime_type in self._data
+            def retrieveData(self, mime_type, type_):
+                return self._data.get(mime_type)
+            def setData(self, mime_type, data):
+                self._data[mime_type] = data
+        
+        mime = MockMimeData()
+        mime.setData("application/x-DataItem", pickled_data)
+
+        # Create a mock DropEvent
+        class MockDropEvent:
+            def __init__(self, mime_data, source_widget):
+                self._mimeData = mime_data
+                self._source_widget = source_widget # Mock the source of the drag
+            def mimeData(self):
+                return self._mimeData
+            def source(self): # To mimic event.source()
+                return self._source_widget
+            def acceptProposedAction(self):
+                print("Drop event accepted.")
+            def ignore(self):
+                print("Drop event ignored.")
+
+        # Mock the VarListWidget as the source of the drag event
+        mock_var_list_widget = QWidget() # Placeholder
+
+        drop_event = MockDropEvent(mime, mock_var_list_widget)
+        main_window.dropEvent(drop_event)
+
+    # Simulate dropping variable for X axis
+    print("\nSimulating drop for X axis (rpm from EngineData.csv)...")
+    simulate_drop('rpm', mock_source1) 
+    print(f"Pending X: {main_window.pending_x_var_name} from {main_window.pending_x_source_id}")
+
+    # Simulate dropping variable for Y axis
+    print("\nSimulating drop for Y axis (load from EngineData.csv)...")
+    simulate_drop('load', mock_source1)
+    print(f"Pending X after Y drop: {main_window.pending_x_var_name} from {main_window.pending_x_source_id}")
+    print(f"Number of traces: {len(main_window.get_traces())}")
+    if main_window.get_traces():
+        print(f"Trace 1 spec: {main_window.get_traces()[0].get_plot_spec()}")
+
+    # Simulate dropping another X
+    print("\nSimulating drop for X axis (speed from TransmissionData.log)...")
+    simulate_drop('speed', mock_source2)
+    print(f"Pending X: {main_window.pending_x_var_name} from {main_window.pending_x_source_id}")
+    
+    # Test clear pending X via context menu action (if possible to simulate menu click easily)
+    # Alternatively, call the method directly
+    # main_window.clear_pending_x_variable()
+    # print(f"Pending X after clear: {main_window.pending_x_var_name}")
+
+
+    # Simulate dropping another Y
+    print("\nSimulating drop for Y axis (torque from TransmissionData.log)...")
+    simulate_drop('torque', mock_source2)
+    print(f"Pending X after Y drop: {main_window.pending_x_var_name} from {main_window.pending_x_source_id}")
+    print(f"Number of traces: {len(main_window.get_traces())}")
+    if len(main_window.get_traces()) > 1:
+        print(f"Trace 2 spec: {main_window.get_traces()[1].get_plot_spec()}")
+    
+    main_window.autoscale_plot()
+
+
+    # Simulate time ticks for marker update
+    def time_updater():
+        for i in range(len(t)):
+            mock_time_emitter.emit_tick(i)
+            QApplication.processEvents() # Allow GUI to update
+            time.sleep(0.02) # 20 ms delay
+        print("Finished time simulation.")
+
+    # Create a simple button to start the time simulation
+    button = QPushButton("Start Time Simulation")
+    main_window.main_layout.addWidget(button) # Add button to layout
+    button.clicked.connect(time_updater)
+
+
+    sys.exit(app.exec_())

--- a/phase_plot_widget.py
+++ b/phase_plot_widget.py
@@ -536,6 +536,9 @@ class PhasePlotWidget(QWidget):
         """Update marker settings from QSettings and refresh display"""
         settings = QSettings()
 
+        # Clear all existing markers before applying new settings
+        self._clear_all_markers()
+
         # Update marker type
         self.current_marker_type = settings.value("phase_plot/default_marker_type", "Circle")
 
@@ -549,6 +552,13 @@ class PhasePlotWidget(QWidget):
 
         # Refresh the marker display with new settings
         self.update_marker(self.last_tick_index)
+
+    def _clear_all_markers(self):
+        """Remove all existing markers from the plot and clear tracking"""
+        for trace_id, marker_items in self.trace_markers.items():
+            for marker_item in marker_items.values():
+                self.plot_widget.removeItem(marker_item)
+        self.trace_markers.clear()
 
     def autoscale_plot(self):
         self.plot_widget.getPlotItem().autoRange()

--- a/plot_manager.py
+++ b/plot_manager.py
@@ -87,6 +87,13 @@ class PlotManager(QWidget):
     def add_subplot(self):
         self.tabs.currentWidget().add_subplot()
 
+    def update_all_cursor_settings(self):
+        """Update cursor settings for all SubPlotWidgets in all tabs"""
+        for i in range(self.tabs.count()):
+            plot_area_widget = self.tabs.widget(i)
+            if hasattr(plot_area_widget, 'update_all_cursor_settings'):
+                plot_area_widget.update_all_cursor_settings()
+
     def handle_key_press(self, event):
         """
         This is the main keypress event handler. It will handle distribution of the various
@@ -298,6 +305,14 @@ class PlotAreaWidget(QWidget):
 
     def _get_plot(self, idx):
         return self.plot_area.itemAt(idx).widget()
+
+    def update_all_cursor_settings(self):
+        """Update cursor settings for all SubPlotWidgets"""
+        n_plots = self.plot_area.count()
+        for i in range(n_plots):
+            plot_widget = self._get_plot(i)
+            if hasattr(plot_widget, 'update_cursor_settings'):
+                plot_widget.update_cursor_settings()
 
     def get_plot_info(self):
         n_plots = self.plot_area.count()

--- a/preferences_dialog.py
+++ b/preferences_dialog.py
@@ -1,7 +1,7 @@
 from PyQt5.QtCore import QSettings
 from PyQt5.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout,
                             QLabel, QPushButton, QGroupBox, QFormLayout,
-                            QLineEdit, QFileDialog)
+                            QLineEdit, QFileDialog, QComboBox, QSpinBox) # Added QComboBox, QSpinBox
 import os
 
 class PreferencesDialog(QDialog):
@@ -43,6 +43,28 @@ class PreferencesDialog(QDialog):
         viz_group.setLayout(viz_layout)
         layout.addWidget(viz_group)
 
+        # Create Phase Plot Settings group
+        phase_plot_group = QGroupBox("Phase Plot Settings")
+        phase_plot_layout = QFormLayout()
+
+        # Default Marker Type
+        self.default_marker_type_combo = QComboBox()
+        self.default_marker_type_combo.addItems(["Circle", "Square", "Crosshairs"]) # pyqtgraph symbols: 'o', 's', '+'
+        current_marker_type = self.settings.value("phase_plot/default_marker_type", "Circle")
+        self.default_marker_type_combo.setCurrentText(current_marker_type)
+        phase_plot_layout.addRow("Default Marker Type:", self.default_marker_type_combo)
+
+        # Default Marker Size
+        self.default_marker_size_spinbox = QSpinBox()
+        self.default_marker_size_spinbox.setMinimum(1)
+        self.default_marker_size_spinbox.setMaximum(50)
+        current_marker_size = int(self.settings.value("phase_plot/default_marker_size", 10))
+        self.default_marker_size_spinbox.setValue(current_marker_size)
+        phase_plot_layout.addRow("Default Marker Size:", self.default_marker_size_spinbox)
+        
+        phase_plot_group.setLayout(phase_plot_layout)
+        layout.addWidget(phase_plot_group)
+
         # Add buttons
         button_layout = QHBoxLayout()
         self.ok_button = QPushButton("OK")
@@ -80,4 +102,9 @@ class PreferencesDialog(QDialog):
         """Save the current settings to QSettings"""
         self.settings.setValue("urdf_path", self.urdf_path.text())
         self.settings.setValue("geometry_json", self.geometry_json.text())
+
+        # Save Phase Plot settings
+        self.settings.setValue("phase_plot/default_marker_type", self.default_marker_type_combo.currentText())
+        self.settings.setValue("phase_plot/default_marker_size", self.default_marker_size_spinbox.value())
+        
         self.settings.sync()

--- a/sub_plot_widget.py
+++ b/sub_plot_widget.py
@@ -202,3 +202,12 @@ class SubPlotWidget(QWidget):
         cb = QApplication.clipboard()
         cb.setPixmap(self.grab())
         print("Plot copied to clipboard.")
+
+    def update_cursor_settings(self):
+        """Update cursor appearance from settings"""
+        from PyQt5.QtCore import QSettings
+        settings = QSettings()
+        cursor_color = settings.value("cursor/color", "black")
+        cursor_width = int(settings.value("cursor/width", 2))
+        pen = pg.mkPen(color=cursor_color, width=cursor_width)
+        self.cursor.setPen(pen)


### PR DESCRIPTION
Adds a new dockable "Phase Plot" widget to the application.

Key features include:
- Dockable and tabbed interface: Multiple phase plot widgets can be opened, each containing multiple phase plot tabs.
- Multiple traces: Each phase plot can display multiple X-Y traces.
- Variable selection: You can drag variables from the variable list and drop them onto the phase plot to define X and then Y axes for a trace.
- Configurable markers:
    - A marker is displayed on each trace corresponding to the current time cursor position.
    - Marker type (Circle, Square, Crosshairs) and size are configurable.
    - Defaults for marker type and size can be set in the Preferences dialog.
    - "Crosshairs" marker type extends lines to the axes.
- Legend: A legend displays the X and Y variable names for each trace, formatted as "x: <var_x_name> - y: <var_y_name>", using a FlowLayout.
- Interactivity:
    - Pan and zoom using standard mouse interactions (scroll wheel, drag-to-zoom via context menu).
    - Ctrl+A autoscales the plot to fit all data.
- State persistence: The state of phase plot widgets (open tabs, variables plotted, marker configurations) is saved with QSettings and restored when the application reopens.
- Integration: Added to the "Tools" menu for creation.

The implementation involves new classes:
- `PhasePlotItem`: Manages a single X-Y trace.
- `PhasePlotWidget`: Manages a single plot area with multiple traces, legend, and markers.
- `DockedPhasePlotWidget`: Provides the dockable, tabbed container for `PhasePlotWidget` instances.

Existing application components (`main.py`, `preferences_dialog.py`, `docked_widget.py`) were updated to support this new feature.