### PR TITLE
Improves import helper functionality

### DIFF
--- a/imports.py
+++ b/imports.py
@@ -1,5 +1,22 @@
 import importlib
 
+def _install_via_conda(module: str):
+    import subprocess
+    try:
+        subprocess.check_call(["conda", "install", "-y", "-c", "conda-forge", module])
+        return True
+    except subprocess.CalledProcessError:
+        print(f"  Failed to install {module} via conda.")
+        return False
+
+def _install_via_pip(module: str):
+    import subprocess
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "-e", module])
+        return True
+    except subprocess.CalledProcessError:
+        print(f"  Failed to install {module} via pip.")
+        return False
 
 def install_and_import(module: str):
     try:
@@ -9,12 +26,16 @@ def install_and_import(module: str):
         import os
         import sys
         is_conda = os.path.exists(os.path.join(sys.base_prefix, 'conda-meta'))
-        import subprocess
+        print(f"Installing {module}. Please wait...")
+
+        install_fcn = []
         if is_conda:
-            print(f"Installing {module}. Please wait...")
-            subprocess.check_call(["conda", "install", "-y", module])
-        else:
-            subprocess.check_call([sys.executable, "-m", "pip", "install", module])
+            install_fcn.append(_install_via_conda)
+        install_fcn.append(_install_via_pip)
+
+        for install in install_fcn:
+            if install(module):
+                break;
 
         i_mod = importlib.import_module(module)
 

--- a/maths_widget.py
+++ b/maths_widget.py
@@ -12,6 +12,8 @@ import numpy as np
 import pickle
 import time
 
+from imports import install_and_import
+
 from var_list_widget import VarListWidget
 
 from maths.filter import FilterSpec
@@ -22,15 +24,8 @@ from maths.running_minmax import RunningMinMaxSpec
 from data_model import DataItem
 from docked_widget import DockedWidget
 
-try:
-    from py_expression_eval import Parser
-except ModuleNotFoundError:
-    import subprocess
-    import sys
-
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "py_expression_eval"])
-    from py_expression_eval import Parser
-
+py_expression_eval = install_and_import("py_expression_eval")
+from py_expression_eval import Parser
 
 class DockedMathsWidget(DockedWidget):
 


### PR DESCRIPTION
*  Handles failed conda installs by falling back to pip
*  Use these changes to install py_expression_eval
