### PR TITLE
feat: Display variable values in VarListWidget

### DIFF
--- a/data_file_widget.py
+++ b/data_file_widget.py
@@ -104,7 +104,14 @@ class DataFileWidget(QWidget):
         # Set callback in the model so it can update the checkbox
         var_list.model()._checkbox_update_callback = update_checkbox_state
 
-        tab_layout.addWidget(derived_checkbox)
+        checkbox_layout = QHBoxLayout()
+        checkbox_layout.addWidget(derived_checkbox)
+
+        show_values_checkbox = QCheckBox("Show values")
+        show_values_checkbox.toggled.connect(var_list.set_show_values)
+        checkbox_layout.addWidget(show_values_checkbox)
+
+        tab_layout.addLayout(checkbox_layout)
         tab_layout.addWidget(var_list)
 
         tab_name = os.path.basename(filepath)
@@ -157,6 +164,11 @@ class DataFileWidget(QWidget):
         if self.tabs.count() == 0:
             return None
         return self.get_data_file(idx).time
+
+    def update_tick(self, tick):
+        active_widget = self.get_active_data_file()
+        if active_widget:
+            active_widget.update_tick(tick)
 
     @pyqtSlot(QPoint)
     def on_context_menu_request(self, pos):

--- a/main.py
+++ b/main.py
@@ -107,6 +107,7 @@ class PyPlot(QMainWindow):
         tick_time_indicator = TimeTickWidget()
         self.plot_manager.tickValueChanged.connect(tick_time_indicator.update_tick)
         self.plot_manager.timeValueChanged.connect(tick_time_indicator.update_time)
+        self.plot_manager.tickValueChanged.connect(self.data_file_widget.update_tick)
         self.statusBar().addPermanentWidget(tick_time_indicator)
 
         self._settings = QSettings()

--- a/var_list_widget.py
+++ b/var_list_widget.py
@@ -59,6 +59,14 @@ class VarListWidget(QListView):
         self.model().set_time_offset(time_offset)
         self.timeChanged.emit()
 
+    def set_show_values(self, show):
+        self.model().set_show_values(show)
+        self.model().layoutChanged.emit()
+
+    def update_tick(self, tick):
+        self.model().set_current_tick(tick)
+        self.model().layoutChanged.emit()
+
     def close(self):
         self.onClose.emit()
         return super().close()


### PR DESCRIPTION
This commit introduces a feature to display the values of each variable in the `VarListWidget` corresponding to the current time, as indicated by the plot cursor.

- A "Show values" checkbox has been added to the `DataFileWidget` to toggle this functionality.
- The `DataModel` has been extended to track the current tick and whether to display values. The `data()` method now formats the display string to include the variable's value when the feature is enabled.
- Signal/slot connections have been added to propagate the cursor's tick from the `PlotManager` to the `DataModel` and to update the view when the cursor moves or the checkbox state changes.